### PR TITLE
Modular nwb to bids

### DIFF
--- a/ando/tools/generator/bidsconverter.py
+++ b/ando/tools/generator/bidsconverter.py
@@ -1,12 +1,13 @@
+import json
+import shutil
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from pathlib import Path
+
 import pandas as pd
-import json
-import shutil
-from ando.AnDOChecker import is_valid
 from tqdm import tqdm
 
+from ando.AnDOChecker import is_valid
 
 REQ_FILES = dict(description='dataset_description.json',
                  participant='participants.tsv',
@@ -19,9 +20,8 @@ REQ_FILES = dict(description='dataset_description.json',
 
 
 class BidsConverter(ABC):
-
     file_type = ''
-    
+
     def __init__(self, dataset_path, **kwargs):
         self.dataset_path = Path(dataset_path)
         self.output_path = self.dataset_path.parent/'BIDSExt'/self.dataset_path.name
@@ -50,7 +50,7 @@ class BidsConverter(ABC):
             file.close()
 
     def _tqdm(self, tqdm_obj, desc):
-        t=tqdm(tqdm_obj)
+        t = tqdm(tqdm_obj)
         t.set_description(desc)
         return t
 
@@ -63,9 +63,9 @@ class BidsConverter(ABC):
                 if participants_df is None:
                     participants_df = participant_df
                 else:
-                    participants_df=participants_df.append(participant_df)
+                    participants_df = participants_df.append(participant_df)
                 self._labels_dict[sub_label] = []
-        self._participants_dict=self._get_default_dict('participant', data=participants_df)['']
+        self._participants_dict = self._get_default_dict('participant', data=participants_df)['']
 
     def _create_description_json(self):
         self._dataset_desc_json = self._get_default_dict('description',
@@ -110,7 +110,6 @@ class BidsConverter(ABC):
     @abstractmethod
     def _get_subject_label(self, file):
         pass
-
 
     @abstractmethod
     def _get_session_label(self, file):
@@ -176,8 +175,8 @@ class BidsConverter(ABC):
         write_path.parent.mkdir(parents=True, exist_ok=True)
         assert isinstance(data, dict), f'{data} should be a dict'
         if not write_path.exists():
-            with open(write_path,'w') as j:
-                json.dump(data,j)
+            with open(write_path, 'w') as j:
+                json.dump(data, j)
 
     @staticmethod
     def _move_data_file(source, dest, move=True):
@@ -213,7 +212,7 @@ class BidsConverter(ABC):
                 data, loc = self._parse_data_dict(
                     self._channels_dict[participant][session],
                     self.output_path)
-                self._write_tsv(data,loc)
+                self._write_tsv(data, loc)
                 data, loc = self._parse_data_dict(
                     self._probes_dict[participant][session],
                     self.output_path)

--- a/ando/tools/generator/bidsconverter.py
+++ b/ando/tools/generator/bidsconverter.py
@@ -51,14 +51,9 @@ class BidsConverter(ABC):
         for file in self._datafiles_io:
             file.close()
 
-    def _tqdm(self, tqdm_obj, desc):
-        t = tqdm(tqdm_obj)
-        t.set_description(desc)
-        return t
-
     def _create_participant_df(self):
         participants_df = None
-        for file in self._tqdm(self._datafiles, "participant"):
+        for file in tqdm(self._datafiles, desc="participant"):
             participant_df = self._get_participant_info(file)
             sub_label = participant_df["ParticipantID"][0]
             if sub_label not in self._labels_dict:
@@ -77,7 +72,7 @@ class BidsConverter(ABC):
         )[""]
 
     def _create_session_df(self):
-        for file in self._tqdm(self._datafiles, "session"):
+        for file in tqdm(self._datafiles, desc="session"):
             subject_name = self._get_subject_label(file)
             session_label = self._get_session_label(file)
             session_df = self._get_session_info(file)
@@ -92,7 +87,7 @@ class BidsConverter(ABC):
             )[session_label]
 
     def _create_sessionlevel_data(self):
-        for no, file in enumerate(self._tqdm(self._datafiles, "sessionlevel")):
+        for no, file in enumerate(tqdm(self._datafiles, desc="sessionlevel")):
             subject_name = self._get_subject_label(file)
             session_label = self._get_session_label(file)
             self._probes_dict[subject_name].update(

--- a/ando/tools/generator/bidsconverter.py
+++ b/ando/tools/generator/bidsconverter.py
@@ -9,22 +9,24 @@ from tqdm import tqdm
 
 from ando.AnDOChecker import is_valid
 
-REQ_FILES = dict(description='dataset_description.json',
-                 participant='participants.tsv',
-                 session='{subject_label}\\{subject_label}_sessions.tsv',
-                 channels='{subject_label}\\{session_label}\\ephys\\{subject_label}_{session_label}_channels.tsv',
-                 contacts='{subject_label}\\{session_label}\\ephys\\{subject_label}_{session_label}_contacts.tsv',
-                 ephys='{subject_label}\\{session_label}\\ephys\\{subject_label}_{session_label}_ephys.json',
-                 probes='{subject_label}\\{session_label}\\ephys\\{subject_label}_{session_label}_probes.tsv',
-                 file='{subject_label}\\{session_label}\\ephys\\{subject_label}_{session_label}_ephys{file_type}')
+REQ_FILES = dict(
+    description="dataset_description.json",
+    participant="participants.tsv",
+    session="{subject_label}\\{subject_label}_sessions.tsv",
+    channels="{subject_label}\\{session_label}\\ephys\\{subject_label}_{session_label}_channels.tsv",
+    contacts="{subject_label}\\{session_label}\\ephys\\{subject_label}_{session_label}_contacts.tsv",
+    ephys="{subject_label}\\{session_label}\\ephys\\{subject_label}_{session_label}_ephys.json",
+    probes="{subject_label}\\{session_label}\\ephys\\{subject_label}_{session_label}_probes.tsv",
+    file="{subject_label}\\{session_label}\\ephys\\{subject_label}_{session_label}_ephys{file_type}",
+)
 
 
 class BidsConverter(ABC):
-    file_type = ''
+    file_type = ""
 
     def __init__(self, dataset_path, **kwargs):
         self.dataset_path = Path(dataset_path)
-        self.output_path = self.dataset_path.parent/'BIDSExt'/self.dataset_path.name
+        self.output_path = self.dataset_path.parent / "BIDSExt" / self.dataset_path.name
         self._kwargs = kwargs
         self._participants_dict = dict()
         self._dataset_desc_json = dict()
@@ -34,8 +36,8 @@ class BidsConverter(ABC):
         self._ephys_dict = defaultdict(dict)
         self._probes_dict = defaultdict(dict)
         self._file_name_dict = defaultdict(dict)
-        self.datafiles_list = list(self.dataset_path.glob(f'**/*{self.file_type}'))
-        assert len(self.datafiles_list) > 0, f'no files of type {self.file_type} found'
+        self.datafiles_list = list(self.dataset_path.glob(f"**/*{self.file_type}"))
+        assert len(self.datafiles_list) > 0, f"no files of type {self.file_type} found"
         self._datafiles_io = self._datafiles_open()
         self._datafiles = [file.read() for file in self._datafiles_io]
         self._labels_dict = defaultdict(list)
@@ -56,56 +58,92 @@ class BidsConverter(ABC):
 
     def _create_participant_df(self):
         participants_df = None
-        for file in self._tqdm(self._datafiles, 'participant'):
+        for file in self._tqdm(self._datafiles, "participant"):
             participant_df = self._get_participant_info(file)
-            sub_label = participant_df['ParticipantID'][0]
+            sub_label = participant_df["ParticipantID"][0]
             if sub_label not in self._labels_dict:
                 if participants_df is None:
                     participants_df = participant_df
                 else:
                     participants_df = participants_df.append(participant_df)
                 self._labels_dict[sub_label] = []
-        self._participants_dict = self._get_default_dict('participant', data=participants_df)['']
+        self._participants_dict = self._get_default_dict(
+            "participant", data=participants_df
+        )[""]
 
     def _create_description_json(self):
-        self._dataset_desc_json = self._get_default_dict('description',
-                                                         data=self._get_dataset_info(self._datafiles[0]))['']
+        self._dataset_desc_json = self._get_default_dict(
+            "description", data=self._get_dataset_info(self._datafiles[0])
+        )[""]
 
     def _create_session_df(self):
-        for file in self._tqdm(self._datafiles, 'session'):
+        for file in self._tqdm(self._datafiles, "session"):
             subject_name = self._get_subject_label(file)
             session_label = self._get_session_label(file)
             session_df = self._get_session_info(file)
-            sessions_df = self._sessions_dict.get(subject_name,
-                                                  dict(data=pd.DataFrame(
-                                                      columns=session_df.columns)))['data']
-            if not sessions_df['session_id'].str.contains(session_label).any():
+            sessions_df = self._sessions_dict.get(
+                subject_name, dict(data=pd.DataFrame(columns=session_df.columns))
+            )["data"]
+            if not sessions_df["session_id"].str.contains(session_label).any():
                 sessions_df = sessions_df.append(session_df)
                 self._labels_dict[subject_name].append(session_label)
             self._sessions_dict[subject_name] = self._get_default_dict(
-                'session', subject_name, session_label, data=sessions_df)[session_label]
+                "session", subject_name, session_label, data=sessions_df
+            )[session_label]
 
     def _create_sessionlevel_data(self):
-        for no, file in enumerate(self._tqdm(self._datafiles, 'sessionlevel')):
+        for no, file in enumerate(self._tqdm(self._datafiles, "sessionlevel")):
             subject_name = self._get_subject_label(file)
             session_label = self._get_session_label(file)
-            self._probes_dict[subject_name].update(self._get_default_dict(
-                'probes', subject_name, session_label, data=self._get_probes_info(file)))
-            self._ephys_dict[subject_name].update(self._get_default_dict(
-                'ephys', subject_name, session_label, data=self._get_ephys_info(file)))
-            self._channels_dict[subject_name].update(self._get_default_dict(
-                'channels', subject_name, session_label, data=self._get_channels_info(file)))
-            self._contacts_dict[subject_name].update(self._get_default_dict(
-                'contacts', subject_name, session_label, data=self._get_contacts_info(file)))
-            self._file_name_dict[subject_name].update(self._get_default_dict(
-                'file', subject_name, session_label, data=self.datafiles_list[no]))
+            self._probes_dict[subject_name].update(
+                self._get_default_dict(
+                    "probes",
+                    subject_name,
+                    session_label,
+                    data=self._get_probes_info(file),
+                )
+            )
+            self._ephys_dict[subject_name].update(
+                self._get_default_dict(
+                    "ephys",
+                    subject_name,
+                    session_label,
+                    data=self._get_ephys_info(file),
+                )
+            )
+            self._channels_dict[subject_name].update(
+                self._get_default_dict(
+                    "channels",
+                    subject_name,
+                    session_label,
+                    data=self._get_channels_info(file),
+                )
+            )
+            self._contacts_dict[subject_name].update(
+                self._get_default_dict(
+                    "contacts",
+                    subject_name,
+                    session_label,
+                    data=self._get_contacts_info(file),
+                )
+            )
+            self._file_name_dict[subject_name].update(
+                self._get_default_dict(
+                    "file", subject_name, session_label, data=self.datafiles_list[no]
+                )
+            )
 
-    def _get_default_dict(self, key, subject_label='', session_label='', data=None):
-        return {session_label: dict(
-            name=REQ_FILES[key].format(subject_label=subject_label,
-                                       session_label=session_label,
-                                       file_type=self.file_type),
-            data=data)}
+    def _get_default_dict(self, key, subject_label="", session_label="", data=None):
+        return {
+            session_label: dict(
+                name=REQ_FILES[key].format(
+                    subject_label=subject_label,
+                    session_label=session_label,
+                    file_type=self.file_type,
+                ),
+                data=data,
+            )
+        }
 
     @abstractmethod
     def _get_subject_label(self, file):
@@ -153,29 +191,31 @@ class BidsConverter(ABC):
         self._create_session_df()
         self._create_sessionlevel_data()
         self._create_description_json()
-        return dict(description=self._dataset_desc_json,
-                    sessions=self._sessions_dict,
-                    participant=self._participants_dict,
-                    probes=self._probes_dict,
-                    ephys=self._ephys_dict,
-                    channels=self._channels_dict,
-                    contacts=self._contacts_dict,
-                    file=self._file_name_dict)
+        return dict(
+            description=self._dataset_desc_json,
+            sessions=self._sessions_dict,
+            participant=self._participants_dict,
+            probes=self._probes_dict,
+            ephys=self._ephys_dict,
+            channels=self._channels_dict,
+            contacts=self._contacts_dict,
+            file=self._file_name_dict,
+        )
 
     @staticmethod
     def _write_tsv(data, write_path):
         write_path.parent.mkdir(parents=True, exist_ok=True)
-        assert isinstance(data, pd.DataFrame), f'{data} should be a df'
+        assert isinstance(data, pd.DataFrame), f"{data} should be a df"
         if not write_path.exists():
-            data.dropna(axis='columns', how='all', inplace=True)
-            data.to_csv(write_path, sep='\t', index=False)
+            data.dropna(axis="columns", how="all", inplace=True)
+            data.to_csv(write_path, sep="\t", index=False)
 
     @staticmethod
     def _write_json(data, write_path):
         write_path.parent.mkdir(parents=True, exist_ok=True)
-        assert isinstance(data, dict), f'{data} should be a dict'
+        assert isinstance(data, dict), f"{data} should be a dict"
         if not write_path.exists():
-            with open(write_path, 'w') as j:
+            with open(write_path, "w") as j:
                 json.dump(data, j)
 
     @staticmethod
@@ -188,96 +228,91 @@ class BidsConverter(ABC):
             if not dest.exists():
                 dest.symlink_to(source)
 
-    def organize(self, output_path=None, move_file=False,
-                 re_write=True, validate=True):
+    def organize(self, output_path=None, move_file=False, re_write=True, validate=True):
         if output_path is not None:
             self.output_path = Path(output_path)
         if re_write and self.output_path.exists():
             shutil.rmtree(self.output_path)
         self.output_path.mkdir(parents=True, exist_ok=True)
-        data, loc = self._parse_data_dict(
-            self._participants_dict,
-            self.output_path)
+        data, loc = self._parse_data_dict(self._participants_dict, self.output_path)
         self._write_tsv(data, loc)
-        data, loc = self._parse_data_dict(
-            self._dataset_desc_json,
-            self.output_path)
+        data, loc = self._parse_data_dict(self._dataset_desc_json, self.output_path)
         self._write_json(data, loc)
         for participant, sessions in self._labels_dict.items():
             data, loc = self._parse_data_dict(
-                self._sessions_dict[participant],
-                self.output_path)
+                self._sessions_dict[participant], self.output_path
+            )
             self._write_tsv(data, loc)
             for session in sessions:
                 data, loc = self._parse_data_dict(
-                    self._channels_dict[participant][session],
-                    self.output_path)
+                    self._channels_dict[participant][session], self.output_path
+                )
                 self._write_tsv(data, loc)
                 data, loc = self._parse_data_dict(
-                    self._probes_dict[participant][session],
-                    self.output_path)
+                    self._probes_dict[participant][session], self.output_path
+                )
                 self._write_tsv(data, loc)
                 data, loc = self._parse_data_dict(
-                    self._contacts_dict[participant][session],
-                    self.output_path)
+                    self._contacts_dict[participant][session], self.output_path
+                )
                 self._write_tsv(data, loc)
                 data, loc = self._parse_data_dict(
-                    self._ephys_dict[participant][session],
-                    self.output_path)
+                    self._ephys_dict[participant][session], self.output_path
+                )
                 self._write_json(data, loc)
                 data, loc = self._parse_data_dict(
-                    self._file_name_dict[participant][session],
-                    self.output_path)
+                    self._file_name_dict[participant][session], self.output_path
+                )
                 self._move_data_file(data, loc, move=move_file)
         if validate:
             is_valid(self.output_path)
 
     def _parse_data_dict(self, data_dict, output_path):
-        return data_dict['data'], output_path/data_dict['name']
+        return data_dict["data"], output_path / data_dict["name"]
 
     def get_subject_names(self):
-        return list(self._participants_dict['data']['ParticipantID'])
+        return list(self._participants_dict["data"]["ParticipantID"])
 
     def get_session_names(self, subject_name=None):
         if subject_name is None:
             subject_name = self.get_subject_names()[0]
-        return list(self._sessions_dict[subject_name]['data']['session_id'])
+        return list(self._sessions_dict[subject_name]["data"]["session_id"])
 
     def get_channels_info(self, subject_name=None, session_name=None):
         if subject_name is None:
             subject_name = self.get_subject_names()[0]
         if session_name is None:
             session_name = self.get_session_names()[0]
-        return self._channels_dict[subject_name][session_name]['data'].to_dict()
+        return self._channels_dict[subject_name][session_name]["data"].to_dict()
 
     def get_contacts_info(self, subject_name=None, session_name=None):
         if subject_name is None:
             subject_name = self.get_subject_names()[0]
         if session_name is None:
             session_name = self.get_session_names()[0]
-        return self._contacts_dict[subject_name][session_name]['data'].to_dict()
+        return self._contacts_dict[subject_name][session_name]["data"].to_dict()
 
     def get_ephys_info(self, subject_name=None, session_name=None):
         if subject_name is None:
             subject_name = self.get_subject_names()[0]
         if session_name is None:
             session_name = self.get_session_names()[0]
-        return self._ephys_dict[subject_name][session_name]['data']
+        return self._ephys_dict[subject_name][session_name]["data"]
 
     def get_probes_info(self, subject_name=None, session_name=None):
         if subject_name is None:
             subject_name = self.get_subject_names()[0]
         if session_name is None:
             session_name = self.get_session_names()[0]
-        return self._probes_dict[subject_name][session_name]['data'].to_dict()
+        return self._probes_dict[subject_name][session_name]["data"].to_dict()
 
     def get_participants_info(self):
-        return self._participants_dict['data'].to_dict()
+        return self._participants_dict["data"].to_dict()
 
     def get_dataset_description(self):
-        return self._dataset_desc_json['data']
+        return self._dataset_desc_json["data"]
 
     def get_session_info(self, subject_name=None):
         if subject_name is None:
             subject_name = self.get_subject_names()[0]
-        return self._sessions_dict[subject_name]['data'].to_dict()
+        return self._sessions_dict[subject_name]["data"].to_dict()

--- a/ando/tools/generator/nwb2bidsgenerator.py
+++ b/ando/tools/generator/nwb2bidsgenerator.py
@@ -11,12 +11,13 @@ from .bidsconverter import BidsConverter
 
 class NwbToBIDS(BidsConverter):
 
+    file_type = '.nwb'
+
     def __init__(self, dataset_path, **kwargs):
         super().__init__(dataset_path, **kwargs)
-        self.extract_metadata()
 
     def _datafiles_open(self):
-        return [NWBHDF5IO(file,'r') for file in self.datafiles_list]
+        return [NWBHDF5IO(str(file),'r') for file in self._tqdm(self.datafiles_list,'reading nwbfiles')]
 
     def _get_subject_label(self, file, subject_suffix=''):
         if file.subject is not None:
@@ -45,9 +46,9 @@ class NwbToBIDS(BidsConverter):
         if nwbfile.subject is not None:
             sb = nwbfile.subject
             df_row = [sb.species, subject_label, sb.sex[0] if sb.sex is not None else None,
-                    sb.date_of_birth, sb.age, sb.genotype, sb.weight], subject_label
+                    sb.date_of_birth, sb.age, sb.genotype, sb.weight]
         else:
-            df_row = [None, subject_label, None, None, None, None, None], subject_label
+            df_row = [None, subject_label, None, None, None, None, None]
         participant_df.loc[0] = df_row
         return participant_df
 
@@ -66,7 +67,7 @@ class NwbToBIDS(BidsConverter):
         session_label = self._get_session_label(nwbfile)
         session_df = pd.DataFrame(
             columns=['session_id', '#_trials', 'comment'],
-            data=[session_label, trials_len, nwbfile.session_description])
+            data=[[session_label, trials_len, nwbfile.session_description]])
         return session_df
 
     @staticmethod

--- a/ando/tools/generator/nwb2bidsgenerator.py
+++ b/ando/tools/generator/nwb2bidsgenerator.py
@@ -3,7 +3,6 @@ import re
 import pandas as pd
 from pynwb import NWBHDF5IO
 from pynwb.ecephys import ElectricalSeries
-from tqdm import tqdm
 
 
 from .bidsconverter import BidsConverter

--- a/ando/tools/generator/nwb2bidsgenerator.py
+++ b/ando/tools/generator/nwb2bidsgenerator.py
@@ -8,42 +8,61 @@ from .bidsconverter import BidsConverter
 
 
 class NwbToBIDS(BidsConverter):
-    file_type = '.nwb'
+    file_type = ".nwb"
 
     def __init__(self, dataset_path, **kwargs):
         super().__init__(dataset_path, **kwargs)
 
     def _datafiles_open(self):
-        return [NWBHDF5IO(str(file), 'r') for file in self._tqdm(self.datafiles_list, 'reading nwbfiles')]
+        return [
+            NWBHDF5IO(str(file), "r")
+            for file in self._tqdm(self.datafiles_list, "reading nwbfiles")
+        ]
 
-    def _get_subject_label(self, file, subject_suffix=''):
+    def _get_subject_label(self, file, subject_suffix=""):
         if file.subject is not None:
             sb = file.subject
             if sb.subject_id is not None:
-                sub_id = re.sub(r'[\W_]+', '', sb.subject_id)
-                subject_label = f'sub-{sub_id}'
+                sub_id = re.sub(r"[\W_]+", "", sb.subject_id)
+                subject_label = f"sub-{sub_id}"
             else:
                 subject_label = f'sub-{sb.date_of_birth.strftime("%Y%m%dT%H%M")}'
         else:
-            subject_label = f'sub-noname{subject_suffix}'
+            subject_label = f"sub-noname{subject_suffix}"
         return subject_label
 
     def _get_session_label(self, file):
         if file.session_id is not None:
-            ses_id = re.sub(r'[\W_]+', '', file.session_id)
-            session_label = f'ses-{ses_id}'
+            ses_id = re.sub(r"[\W_]+", "", file.session_id)
+            session_label = f"ses-{ses_id}"
         else:
             session_label = f'ses-{file.session_start_time.strftime("%Y%m%dT%H%M")}'
         return session_label
 
-    def _get_participant_info(self, nwbfile, subject_suffix=''):
+    def _get_participant_info(self, nwbfile, subject_suffix=""):
         subject_label = self._get_subject_label(nwbfile, subject_suffix)
         participant_df = pd.DataFrame(
-            columns=['Species', 'ParticipantID', 'Sex', 'Birthdate', 'Age', 'Genotype', 'Weight'])
+            columns=[
+                "Species",
+                "ParticipantID",
+                "Sex",
+                "Birthdate",
+                "Age",
+                "Genotype",
+                "Weight",
+            ]
+        )
         if nwbfile.subject is not None:
             sb = nwbfile.subject
-            df_row = [sb.species, subject_label, sb.sex[0] if sb.sex is not None else None,
-                      sb.date_of_birth, sb.age, sb.genotype, sb.weight]
+            df_row = [
+                sb.species,
+                subject_label,
+                sb.sex[0] if sb.sex is not None else None,
+                sb.date_of_birth,
+                sb.age,
+                sb.genotype,
+                sb.weight,
+            ]
         else:
             df_row = [None, subject_label, None, None, None, None, None]
         participant_df.loc[0] = df_row
@@ -52,29 +71,38 @@ class NwbToBIDS(BidsConverter):
     @staticmethod
     def _get_dataset_info(nwbfile):
         return dict(
-            InstitutionName=nwbfile.institution, InstitutionalDepartmentName=nwbfile.lab,
-            Name='Electrophysiology', BIDSVersion='1.0.X',
-            Licence='CC BY 4.0',
+            InstitutionName=nwbfile.institution,
+            InstitutionalDepartmentName=nwbfile.lab,
+            Name="Electrophysiology",
+            BIDSVersion="1.0.X",
+            Licence="CC BY 4.0",
             Authors=[
-                list(nwbfile.experimenter) if nwbfile.experimenter is not None else None][0])
+                list(nwbfile.experimenter) if nwbfile.experimenter is not None else None
+            ][0],
+        )
 
     def _get_session_info(self, nwbfile):
-        trials_len = len(
-            nwbfile.trials) if nwbfile.trials is not None else None
+        trials_len = len(nwbfile.trials) if nwbfile.trials is not None else None
         session_label = self._get_session_label(nwbfile)
         session_df = pd.DataFrame(
-            columns=['session_id', '#_trials', 'comment'],
-            data=[[session_label, trials_len, nwbfile.session_description]])
+            columns=["session_id", "#_trials", "comment"],
+            data=[[session_label, trials_len, nwbfile.session_description]],
+        )
         return session_df
 
     @staticmethod
     def _get_channels_info(nwbfile):
         channels_df = pd.DataFrame(
-            columns=['channel_id', 'Contact_id', 'type', 'units', 'sampling_frequency',
-                     'unit_conversion_multiplier'])
-        es = [
-            i for i in nwbfile.children if isinstance(
-                i, ElectricalSeries)]
+            columns=[
+                "channel_id",
+                "Contact_id",
+                "type",
+                "units",
+                "sampling_frequency",
+                "unit_conversion_multiplier",
+            ]
+        )
+        es = [i for i in nwbfile.children if isinstance(i, ElectricalSeries)]
         if len(es) > 0:
             es = es[0]
             no_channels = es.data.shape[1]
@@ -82,42 +110,45 @@ class NwbToBIDS(BidsConverter):
             conversion = es.conversion
             unit = es.unit
             for chan_no in range(no_channels):
-                channels_df.loc[len(channels_df.index)] = [chan_no, chan_no, 'neural signal',
-                                                           unit,
-                                                           sampling_frequency, conversion]
+                channels_df.loc[len(channels_df.index)] = [
+                    chan_no,
+                    chan_no,
+                    "neural signal",
+                    unit,
+                    sampling_frequency,
+                    conversion,
+                ]
         return channels_df
 
     @staticmethod
     def _get_ephys_info(nwbfile, **kwargs):
-        return dict(PowerLineFrequency=kwargs.get('powerlinefrequency', 50.0))
+        return dict(PowerLineFrequency=kwargs.get("powerlinefrequency", 50.0))
 
     @staticmethod
     def _get_contacts_info(nwbfile):
         contacts_df = pd.DataFrame(
-            columns=[
-                'x',
-                'y',
-                'z',
-                'impedance',
-                'contact_id',
-                'probe_id',
-                'Location'])
+            columns=["x", "y", "z", "impedance", "contact_id", "probe_id", "Location"]
+        )
         e_table = nwbfile.electrodes
         if e_table is not None:
             for contact_no in range(len(e_table)):
-                contacts_df.loc[len(contacts_df.index)] = [e_table.x[contact_no],
-                                                           e_table.y[contact_no],
-                                                           e_table.z[contact_no],
-                                                           e_table.imp[contact_no],
-                                                           contact_no,
-                                                           e_table.group[contact_no].device.name,
-                                                           e_table.location[contact_no]]
+                contacts_df.loc[len(contacts_df.index)] = [
+                    e_table.x[contact_no],
+                    e_table.y[contact_no],
+                    e_table.z[contact_no],
+                    e_table.imp[contact_no],
+                    contact_no,
+                    e_table.group[contact_no].device.name,
+                    e_table.location[contact_no],
+                ]
         return contacts_df
 
     def _get_probes_info(self, nwbfile, **kwargs):
         contacts_df = self._get_contacts_info(nwbfile)
-        probes_df = pd.DataFrame(columns=['probeID', 'type'])
-        for probe_id in contacts_df['probe_id'].unique():
+        probes_df = pd.DataFrame(columns=["probeID", "type"])
+        for probe_id in contacts_df["probe_id"].unique():
             probes_df.loc[len(probes_df.index)] = [
-                probe_id, kwargs.get('probe_type', 'acute')]
+                probe_id,
+                kwargs.get("probe_type", "acute"),
+            ]
         return probes_df

--- a/ando/tools/generator/nwb2bidsgenerator.py
+++ b/ando/tools/generator/nwb2bidsgenerator.py
@@ -4,19 +4,17 @@ import pandas as pd
 from pynwb import NWBHDF5IO
 from pynwb.ecephys import ElectricalSeries
 
-
 from .bidsconverter import BidsConverter
 
 
 class NwbToBIDS(BidsConverter):
-
     file_type = '.nwb'
 
     def __init__(self, dataset_path, **kwargs):
         super().__init__(dataset_path, **kwargs)
 
     def _datafiles_open(self):
-        return [NWBHDF5IO(str(file),'r') for file in self._tqdm(self.datafiles_list,'reading nwbfiles')]
+        return [NWBHDF5IO(str(file), 'r') for file in self._tqdm(self.datafiles_list, 'reading nwbfiles')]
 
     def _get_subject_label(self, file, subject_suffix=''):
         if file.subject is not None:
@@ -45,7 +43,7 @@ class NwbToBIDS(BidsConverter):
         if nwbfile.subject is not None:
             sb = nwbfile.subject
             df_row = [sb.species, subject_label, sb.sex[0] if sb.sex is not None else None,
-                    sb.date_of_birth, sb.age, sb.genotype, sb.weight]
+                      sb.date_of_birth, sb.age, sb.genotype, sb.weight]
         else:
             df_row = [None, subject_label, None, None, None, None, None]
         participant_df.loc[0] = df_row

--- a/ando/tools/generator/nwb2bidsgenerator.py
+++ b/ando/tools/generator/nwb2bidsgenerator.py
@@ -3,6 +3,7 @@ import re
 import pandas as pd
 from pynwb import NWBHDF5IO
 from pynwb.ecephys import ElectricalSeries
+from tqdm import tqdm
 
 from .bidsconverter import BidsConverter
 
@@ -16,7 +17,7 @@ class NwbToBIDS(BidsConverter):
     def _datafiles_open(self):
         return [
             NWBHDF5IO(str(file), "r")
-            for file in self._tqdm(self.datafiles_list, "reading nwbfiles")
+            for file in tqdm(self.datafiles_list, desc="reading nwbfiles")
         ]
 
     def _get_subject_label(self, file, subject_suffix=""):

--- a/ando/tools/generator/nwb2bidsgenerator.py
+++ b/ando/tools/generator/nwb2bidsgenerator.py
@@ -1,15 +1,11 @@
-import json
 import re
-import shutil
-from collections import defaultdict
-from pathlib import Path
 
 import pandas as pd
 from pynwb import NWBHDF5IO
 from pynwb.ecephys import ElectricalSeries
 from tqdm import tqdm
 
-from ando.AnDOChecker import is_valid
+
 from .bidsconverter import BidsConverter
 
 
@@ -17,79 +13,43 @@ class NwbToBIDS(BidsConverter):
 
     def __init__(self, dataset_path, **kwargs):
         super().__init__(dataset_path, **kwargs)
-        self.datafiles_list = list(self.dataset_path.glob('**/*.nwb'))
-        assert len(self.datafiles_list) > 0, 'no nwb files found'
-        self._extract_metadata()
+        self.extract_metadata()
 
-    def _extract_metadata(self):
-        self._participants_dict.update(data=pd.DataFrame(
-                                           columns=['Species', 'ParticipantID', 'Sex', 'Birthdate', 'Age', 'Genotype',
-                                                    'Weight']))
-        for file_no, nwb_file in enumerate(tqdm(self.datafiles_list)):
-            with NWBHDF5IO(str(nwb_file), 'r') as io:
-                nwbfile = io.read()
+    def _datafiles_open(self):
+        return [NWBHDF5IO(file,'r') for file in self.datafiles_list]
 
-                # 1) FULL DATASET INFO:
-                # subject info:
-                sub_df, subject_label = self._get_subject_info(nwbfile, subject_suffix=str(file_no))
-                if not self._participants_dict['data']['ParticipantID'].str.contains(
-                        subject_label).any():
-                    self._participants_dict['data'].loc[len(self._participants_dict['data'].index)] = sub_df
-                # dataset_info:
-                if self._dataset_desc_json['data'] is None:
-                    self._dataset_desc_json['data'] = self._get_dataset_info(nwbfile)
-
-                # 2) SUBJECT SPECIFIC:
-                # session info:
-                base_location_1 = Path(f'{subject_label}')
-                session_default_dict = dict(name=base_location_1/f'{subject_label}_sessions.tsv',
-                                            data=pd.DataFrame(
-                                                columns=['session_id', '#_trials', 'comment']))
-                session_info = self._get_session_info(nwbfile)
-                sessions_label = session_info[0]
-                sessions_df = self._sessions_dict.get(subject_label, session_default_dict)['data']
-                if not sessions_df['session_id'].str.contains(sessions_label).any():
-                    sessions_df.loc[len(sessions_df.index)] = session_info
-                    session_default_dict.update(data=sessions_df)
-                self._sessions_dict[subject_label] = session_default_dict
-
-                # 3) SUBJECT>SESSION SPECIFIC:
-                base_location_2 = Path(subject_label)/Path(sessions_label)/Path('ephys')
-                # channels_info:
-                channel_default_dict = dict(name=base_location_2/f'{subject_label}_{sessions_label}_channels.tsv',
-                                            data=self._get_channels_info(nwbfile))
-                self._channels_dict[subject_label].update({sessions_label: channel_default_dict})
-                # ephys_json:
-                ephys_default_dict = dict(name=base_location_2/f'{subject_label}_{sessions_label}_ephys.json',
-                                          data=self._get_ephys_info(nwbfile, **self._kwargs))
-                self._ephys_dict[subject_label].update({sessions_label: ephys_default_dict})
-                # contacts/probes info:
-                contact_df, probes_df = self._get_contacts_info(nwbfile, **self._kwargs)
-                contacts_default_dict = dict(name=base_location_2/f'{subject_label}_{sessions_label}_contacts.tsv',
-                                             data=contact_df)
-                probes_default_dict = dict(name=base_location_2/f'{subject_label}_{sessions_label}_probes.tsv',
-                                           data=probes_df)
-                self._contacts_dict[subject_label].update({sessions_label: contacts_default_dict})
-                self._probes_dict[subject_label].update({sessions_label: probes_default_dict})
-                # nwbfile location:
-                nwbfile_default_dict = dict(name=base_location_2/f'{subject_label}_{sessions_label}_ephys.nwb',
-                                            data=nwb_file)
-                self._nwbfile_name_dict[subject_label].update({sessions_label: nwbfile_default_dict})
-
-    @staticmethod
-    def _get_subject_info(nwbfile, subject_suffix=''):
-        if nwbfile.subject is not None:
-            sb = nwbfile.subject
+    def _get_subject_label(self, file, subject_suffix=''):
+        if file.subject is not None:
+            sb = file.subject
             if sb.subject_id is not None:
                 sub_id = re.sub(r'[\W_]+', '', sb.subject_id)
                 subject_label = f'sub-{sub_id}'
             else:
                 subject_label = f'sub-{sb.date_of_birth.strftime("%Y%m%dT%H%M")}'
-            return [sb.species, subject_label, sb.sex[0] if sb.sex is not None else None,
-                    sb.date_of_birth, sb.age, sb.genotype, sb.weight], subject_label
         else:
             subject_label = f'sub-noname{subject_suffix}'
-            return [None, subject_label, None, None, None, None, None], subject_label
+        return subject_label
+
+    def _get_session_label(self, file):
+        if file.session_id is not None:
+            ses_id = re.sub(r'[\W_]+', '', file.session_id)
+            session_label = f'ses-{ses_id}'
+        else:
+            session_label = f'ses-{file.session_start_time.strftime("%Y%m%dT%H%M")}'
+        return session_label
+
+    def _get_participant_info(self, nwbfile, subject_suffix=''):
+        subject_label = self._get_subject_label(nwbfile, subject_suffix)
+        participant_df = pd.DataFrame(
+            columns=['Species', 'ParticipantID', 'Sex', 'Birthdate', 'Age', 'Genotype', 'Weight'])
+        if nwbfile.subject is not None:
+            sb = nwbfile.subject
+            df_row = [sb.species, subject_label, sb.sex[0] if sb.sex is not None else None,
+                    sb.date_of_birth, sb.age, sb.genotype, sb.weight], subject_label
+        else:
+            df_row = [None, subject_label, None, None, None, None, None], subject_label
+        participant_df.loc[0] = df_row
+        return participant_df
 
     @staticmethod
     def _get_dataset_info(nwbfile):
@@ -100,16 +60,14 @@ class NwbToBIDS(BidsConverter):
             Authors=[
                 list(nwbfile.experimenter) if nwbfile.experimenter is not None else None][0])
 
-    @staticmethod
-    def _get_session_info(nwbfile):
+    def _get_session_info(self, nwbfile):
         trials_len = len(
             nwbfile.trials) if nwbfile.trials is not None else None
-        if nwbfile.session_id is not None:
-            ses_id = re.sub(r'[\W_]+', '', nwbfile.session_id)
-            session_label = f'ses-{ses_id}'
-        else:
-            session_label = f'ses-{nwbfile.session_start_time.strftime("%Y%m%dT%H%M")}'
-        return [session_label, trials_len, nwbfile.session_description]
+        session_label = self._get_session_label(nwbfile)
+        session_df = pd.DataFrame(
+            columns=['session_id', '#_trials', 'comment'],
+            data=[session_label, trials_len, nwbfile.session_description])
+        return session_df
 
     @staticmethod
     def _get_channels_info(nwbfile):
@@ -136,7 +94,7 @@ class NwbToBIDS(BidsConverter):
         return dict(PowerLineFrequency=kwargs.get('powerlinefrequency', 50.0))
 
     @staticmethod
-    def _get_contacts_info(nwbfile, **kwargs):
+    def _get_contacts_info(nwbfile):
         contacts_df = pd.DataFrame(
             columns=[
                 'x',
@@ -146,7 +104,6 @@ class NwbToBIDS(BidsConverter):
                 'contact_id',
                 'probe_id',
                 'Location'])
-        probes_df = pd.DataFrame(columns=['probeID', 'type'])
         e_table = nwbfile.electrodes
         if e_table is not None:
             for contact_no in range(len(e_table)):
@@ -157,84 +114,12 @@ class NwbToBIDS(BidsConverter):
                                                            contact_no,
                                                            e_table.group[contact_no].device.name,
                                                            e_table.location[contact_no]]
+        return contacts_df
+
+    def _get_probes_info(self, nwbfile, **kwargs):
+        contacts_df = self._get_contacts_info(nwbfile)
+        probes_df = pd.DataFrame(columns=['probeID', 'type'])
         for probe_id in contacts_df['probe_id'].unique():
             probes_df.loc[len(probes_df.index)] = [
                 probe_id, kwargs.get('probe_type', 'acute')]
-        return contacts_df, probes_df
-
-    def organize(self, output_path=None, move_nwb=False,
-                 re_write=True, validate=True):
-        if output_path is None:
-            output_path = self.dataset_path.parent/'BIDSExt'/self.dataset_path.name
-        else:
-            output_path = Path(output_path)
-        if re_write and output_path.exists():
-            shutil.rmtree(output_path)
-        # CREATE FILES:
-        # 1) data_desc, participants:
-        output_path.mkdir(parents=True, exist_ok=True)
-        data, loc = self._parse_data_dict(self._participants_dict, output_path)
-        data.dropna(axis='columns', how='all', inplace=True)
-        data.to_csv(loc, sep='\t', index=False)
-        data, loc = self._parse_data_dict(self._dataset_desc_json, output_path)
-        with open(loc, 'w') as j:
-            if all([True for au in data['Authors'] if au is None]):
-                _ = data.pop('Authors')
-            dataset_desc_tosave = {k: v for k,
-                                            v in data.items() if v is not None}
-            json.dump(dataset_desc_tosave, j)
-
-        # 2) sessions.tsv:
-        for ses_file_dict in self._sessions_dict.values():
-            data, loc = self._parse_data_dict(ses_file_dict, output_path)
-            if not loc.parent.exists():
-                loc.parent.mkdir(parents=True)
-            data.to_csv(loc, sep='\t', index=False)
-
-        # 3) subject>sessions>ephys specific files:
-        for subject_id in self._participants_dict['data']['ParticipantID']:
-            for session_id in self._sessions_dict[subject_id]['data']['session_id']:
-                # ephys.json
-                base_loc = output_path/subject_id/session_id/'ephys'
-                if not base_loc.exists():
-                    base_loc.mkdir(parents=True)
-                data, loc = self._parse_data_dict(
-                    self._ephys_dict[subject_id][session_id],
-                    output_path)
-                with open(loc, 'w') as j:
-                    json.dump(data, j)
-                # channels tsv:
-                data, loc = self._parse_data_dict(
-                    self._channels_dict[subject_id][session_id],
-                    output_path)
-                self._write_csv(data, loc)
-                # contacts/probes tsv:
-                data, loc = self._parse_data_dict(
-                    self._contacts_dict[subject_id][session_id],
-                    output_path)
-                self._write_csv(data, loc)
-                data, loc = self._parse_data_dict(
-                    self._probes_dict[subject_id][session_id],
-                    output_path)
-                self._write_csv(data, loc)
-                # nwbfile move:
-                data, loc = self._parse_data_dict(
-                    self._nwbfile_name_dict[subject_id][session_id],
-                    output_path)
-                if move_nwb:
-                    if not loc.exists():
-                        data.replace(loc)
-                else:
-                    if not loc.exists():
-                        loc.symlink_to(data)
-
-        if validate:
-            is_valid(output_path)
-
-    def _parse_data_dict(self, data_dict, output_path):
-        return data_dict['data'], output_path/data_dict['name']
-
-    def _write_csv(self, data, loc):
-        if not loc.exists():
-            data.dropna(axis='columns', how='all', inplace=True)
-            data.to_csv(loc, sep='\t', index=False)
+        return probes_df

--- a/ando/tools/generator/tests/test_nwb2bidsgenerator.py
+++ b/ando/tools/generator/tests/test_nwb2bidsgenerator.py
@@ -4,7 +4,9 @@ from pathlib import Path
 import re
 from datalad.api import install, Dataset
 
-from ando.tools.generator.nwb2bidsgenerator import NwbToBIDS, is_valid
+from ando.tools.generator.nwb2bidsgenerator import NwbToBIDS
+from ando.AnDOChecker import is_valid
+
 
 class TestNwbBIDSGenerator(unittest.TestCase):
 
@@ -25,14 +27,14 @@ class TestNwbBIDSGenerator(unittest.TestCase):
 
     def test_nwb_to_bids(self):
         n2b = NwbToBIDS(self.datadir)
-        n2b.organize(output_path=self.savedir, move_nwb=False, validate=False)
+        n2b.organize(output_path=self.savedir, move_file=False, validate=False)
         validation_output = is_valid(self.savedir)
         if not validation_output[0]:
             raise Exception(','.join(validation_output[1]))
 
     def test_validation(self):
         n2b = NwbToBIDS(self.datadir)
-        n2b.organize(output_path=self.savedir, move_nwb=False, validate=False)
+        n2b.organize(output_path=self.savedir, move_file=False, validate=False)
         svpt = Path(self.savedir)
         for sub_files in svpt.iterdir():
             if sub_files.suffix=='.json':


### PR DESCRIPTION
This PR implements the modular stylistic changes discussed for the base class.
Specifically:
`BIDSConverter `(parent class)>`NwbToBIDS`/or any future converter. 

The `BIDSConverter` hold all the functionality that is common to any format:

1. Aggregate the data that goes into the columns from each of the mandatory data files:
- `self._create_*_df()` which creates a dataframe/json file in memory corresponding to each of the mandatory datasets. Example: `self._create_participant_df()` creates a df of all the required fields with values within the **participant.tsv** file. Each method loops through all the datafiles (.nwb/.nix-future) to retrieve and populate the df columns. The functionality to read the file is of course file dependent so its to be implemented by the child class: `self_get_participant_info()`

2. Creation of various mandatory files:

- `~/participants.tsv, ~/dataset_description.json`
- `~/<sub-label>/<sub-label>_sessions.tsv`
- `~/<sub-label>/<sess-label>_<sub-label>/ephys/*(channels.tsv | contacts.tsv | ephys.json | probes.tsv)`

For this it implements `self.organize()`- which creates the files on disc. THis would be common to any file format again. 

So, essentially, any new converter needs to implement only methods to read the specific info (example: subject_name, contacts_details, probes_details etc) > `self._get_participant_info()`, `self._get_contacts_info()` ..



